### PR TITLE
Link to docs.sharemind.cyber.ee

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
         <li><a href="#"><span class="icon fa-home"></span></a></li>
         <li><a href="#download">Download SDK</a></li>
         <li><a href="#getting-started">Getting started</a></li>
-        <li><a href="#documentation">Documentation</a></li>
+        <li><a href="https://docs.sharemind.cyber.ee">Documentation</a></li>
         <li><a href="release-notes.html#release-notes">Release notes</a></li>
       </ul>
       <a id="nav-button" href="#nav">Menu</a>
@@ -32,7 +32,7 @@
       <ul class="links">
         <li><a href="#download">Download SDK</a></li>
         <li><a href="#getting-started">Getting started</a></li>
-        <li><a href="#documentation">Documentation</a></li>
+        <li><a href="https://docs.sharemind.cyber.ee">Documentation</a></li>
         <li><a href="release-notes.html#release-notes">Release notes</a></li>
       </ul>
       <ul class="actions vertical">
@@ -198,16 +198,6 @@
         </div>
 
         <p><strong>NOTE:</strong> the protocols have no limit on the number of clients. E.g., you can have any number of data sources or data users.</p>
-      </section>
-
-      <a class="anchor adjusted" id="documentation"></a>
-
-      <section>
-        <h2>Documentation</h2>
-        <p>The following developer resources are currently available:</p>
-        <ul>
-          <li><a href="stdlib/reference/index.html" target="_blank">SecreC 2 language and standard library reference</a></li>
-        </ul>
       </section>
 
       <section>


### PR DESCRIPTION
Linking to docs.sharemind.cyber.ee. Maybe this change can be improved, but just linking sharemind-sdk.github.io to the docs site, as it otherwise doesn't seem to do that.  